### PR TITLE
Annotation based access control for Flow views

### DIFF
--- a/src/main/java/com/example/application/ServiceInitListener.java
+++ b/src/main/java/com/example/application/ServiceInitListener.java
@@ -1,0 +1,60 @@
+package com.example.application;
+
+import com.example.application.security.VaadinConnectAccessChecker;
+import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.RouteNotFoundError;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.UIInitEvent;
+import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.VaadinServletRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+public class ServiceInitListener implements VaadinServiceInitListener, UIInitListener, BeforeEnterListener {
+
+    private final VaadinConnectAccessChecker vaadinConnectAccessChecker = new VaadinConnectAccessChecker();
+
+    public ServiceInitListener() {
+        vaadinConnectAccessChecker.enableCsrf(false);
+    }
+
+    // TODO: If we use DenyAll by default, how do we configure navigation targets like these?
+    private static final Class<?>[] NAVIGATION_TARGET_ALLOW_LIST = new Class<?>[]{
+            RouteNotFoundError.class,
+            JavaScriptBootstrapUI.ClientViewPlaceholder.class
+    };
+
+    @Override
+    public void serviceInit(ServiceInitEvent serviceInitEvent) {
+        serviceInitEvent.getSource().addUIInitListener(this);
+    }
+
+    @Override
+    public void uiInit(UIInitEvent uiInitEvent) {
+        uiInitEvent.getUI().addBeforeEnterListener(this);
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent beforeEnterEvent) {
+        if (Arrays.stream(NAVIGATION_TARGET_ALLOW_LIST)
+                .anyMatch(target -> target.isAssignableFrom(beforeEnterEvent.getNavigationTarget()))) {
+            return;
+        }
+
+        VaadinServletRequest vaadinServletRequest = (VaadinServletRequest) VaadinRequest.getCurrent();
+        String error = vaadinConnectAccessChecker.check(
+                beforeEnterEvent.getNavigationTarget(),
+                vaadinServletRequest.getHttpServletRequest());
+        if (error != null) {
+            // TODO: Use Spring's AccessDeniedException? Reroute to login?
+            beforeEnterEvent.rerouteToError(NotFoundException.class);
+        }
+    }
+}

--- a/src/main/java/com/example/application/security/VaadinConnectAccessChecker.java
+++ b/src/main/java/com/example/application/security/VaadinConnectAccessChecker.java
@@ -1,0 +1,153 @@
+package com.example.application.security;
+
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Based on {@link com.vaadin.flow.server.connect.auth.VaadinConnectAccessChecker} with some modifications:
+ *
+ * 1. Some unused methods have been removed.
+ * 2. Some methods that took a {@link Method} as argument now take a {@link Class}, these are commented with
+ * "Modified for Class".
+ */
+public class VaadinConnectAccessChecker {
+
+    private boolean xsrfProtectionEnabled = true;
+
+    /**
+     * Modified for class
+     */
+    public String check (Class<?> target, HttpServletRequest request) {
+        if (request.getUserPrincipal() != null) {
+            return verifyAuthenticatedUser(target, request);
+        } else {
+            return verifyAnonymousUser(target, request);
+        }
+    }
+
+    /**
+     * Modified for class
+     */
+    private String verifyAnonymousUser(Class<?> target,
+                                       HttpServletRequest request) {
+        if (!target.isAnnotationPresent(AnonymousAllowed.class)
+                || cannotAccessClass(target, request)) {
+            return "Anonymous access is not allowed";
+        }
+        return null;
+    }
+
+    /**
+     * Modified for class
+     */
+    private String verifyAuthenticatedUser(Class<?> target,
+                                           HttpServletRequest request) {
+        if (cannotAccessClass(target, request)) {
+            VaadinService vaadinService = VaadinService.getCurrent();
+            final String accessDeniedMessage;
+            if (vaadinService != null && !vaadinService
+                    .getDeploymentConfiguration().isProductionMode()) {
+                // suggest access control annotations in dev mode
+                accessDeniedMessage = "Unauthorized access to Vaadin endpoint; "
+                        + "to enable endpoint access use one of the following "
+                        + "annotations: @AnonymousAllowed, @PermitAll, "
+                        + "@RolesAllowed";
+            } else {
+                accessDeniedMessage = "Unauthorized access to Vaadin endpoint";
+            }
+            return accessDeniedMessage;
+        }
+        return null;
+    }
+
+    /**
+     * Modified for class
+     */
+    private boolean cannotAccessClass(Class<?> target, HttpServletRequest request) {
+        return requestForbidden(request) || !entityAllowed(target, request);
+    }
+
+    private boolean requestForbidden(HttpServletRequest request) {
+        if (!xsrfProtectionEnabled) {
+            return false;
+        }
+
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return false;
+        }
+
+        String csrfTokenInSession = (String) session
+                .getAttribute(VaadinService.getCsrfTokenAttributeName());
+        if (csrfTokenInSession == null) {
+            if (getLogger().isInfoEnabled()) {
+                getLogger().info(
+                        "Unable to verify CSRF token for endpoint request, got null token in session");
+            }
+
+            return true;
+        }
+
+        String csrfTokenInRequest = request.getHeader("X-CSRF-Token");
+        if (csrfTokenInRequest == null || !MessageDigest.isEqual(
+                csrfTokenInSession.getBytes(StandardCharsets.UTF_8),
+                csrfTokenInRequest.getBytes(StandardCharsets.UTF_8))) {
+            if (getLogger().isInfoEnabled()) {
+                getLogger().info("Invalid CSRF token in endpoint request");
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean entityAllowed(AnnotatedElement entity,
+                                  HttpServletRequest request) {
+        if (entity.isAnnotationPresent(DenyAll.class)) {
+            return false;
+        }
+        if (entity.isAnnotationPresent(AnonymousAllowed.class)) {
+            return true;
+        }
+        RolesAllowed rolesAllowed = entity.getAnnotation(RolesAllowed.class);
+        if (rolesAllowed == null) {
+            return entity.isAnnotationPresent(PermitAll.class);
+        } else {
+            return roleAllowed(rolesAllowed, request);
+        }
+    }
+
+    private boolean roleAllowed(RolesAllowed rolesAllowed,
+                                HttpServletRequest request) {
+        for (String role : rolesAllowed.value()) {
+            if (request.isUserInRole(role)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void enableCsrf(boolean xsrfProtectionEnabled) {
+        this.xsrfProtectionEnabled = xsrfProtectionEnabled;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(VaadinConnectAccessChecker.class);
+    }
+}

--- a/src/main/java/com/example/application/views/PrivateJavaView.java
+++ b/src/main/java/com/example/application/views/PrivateJavaView.java
@@ -11,8 +11,11 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
+import javax.annotation.security.RolesAllowed;
+
 @Route(value = "private/java")
 @PageTitle("Private Java")
+@RolesAllowed("user")
 public class PrivateJavaView extends VerticalLayout {
 
     private BankService bankService;
@@ -29,6 +32,9 @@ public class PrivateJavaView extends VerticalLayout {
     }
 
     private void updateBalanceText() {
+        if (utils.getAuthenticatedUser() == null) {
+            throw new IllegalStateException("Unauthenticated user should not be able to open this view");
+        }
         String name = utils.getAuthenticatedUser().getUsername();
         BigDecimal balance = bankService.getBalance();
         this.balanceSpan.setText(String.format("Hello %s, your bank account balance is $%s.", name, balance));

--- a/src/main/java/com/example/application/views/PrivateJavaView.java
+++ b/src/main/java/com/example/application/views/PrivateJavaView.java
@@ -32,13 +32,9 @@ public class PrivateJavaView extends VerticalLayout {
     }
 
     private void updateBalanceText() {
-        if (utils.getAuthenticatedUser() == null) {
-            throw new IllegalStateException("Unauthenticated user should not be able to open this view");
-        }
         String name = utils.getAuthenticatedUser().getUsername();
         BigDecimal balance = bankService.getBalance();
         this.balanceSpan.setText(String.format("Hello %s, your bank account balance is $%s.", name, balance));
-
     }
 
     private void applyForLoan(ClickEvent<Button> e) {

--- a/src/main/java/com/example/application/views/PublicJavaView.java
+++ b/src/main/java/com/example/application/views/PublicJavaView.java
@@ -6,9 +6,11 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 
 @Route(value = "public/java")
 @PageTitle("Public Java")
+@AnonymousAllowed
 public class PublicJavaView extends FlexLayout {
 
     public PublicJavaView() {


### PR DESCRIPTION
Some TODOs to think about still, but this `BeforeEnterListener`-based approach works as follows:

- No annotation -> View can not be accessed
- AnonymousAllowed -> View can be accessed by anonymous users
- Permit all -> View can be accessed by all authenticated users
- RolesAllowed -> View can be accessed by authenticated users with an allowed role

It does not yet check super classes.